### PR TITLE
remove dependency on addOns.js.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ import '../js/thirdparty/iscroll';
 
 import { CIQ, $$$ } from '../js/chartiq';
 
-import '../js/addOns';
 import '../js/translations';
 // import '../plugins/tfc/tfc';
 import '../js/plugin';
@@ -113,27 +112,6 @@ stxx.attachQuoteFeed(new Feed(_streamManager, stxx), {
 // Optionally set a market factory to the chart to make it market hours aware. Otherwise it will operate in 24x7 mode.
 // This is required for the simulator, or if you intend to also enable Extended hours trading zones.
 stxx.setMarketFactory(CIQ.Market.Symbology.factory);
-
-// Extended hours trading zones -- Make sure this is instantiated before calling startUI as a timing issue with may occur
-new CIQ.ExtendedHours({
-    stx: stxx,
-    filter: true,
-});
-
-// Floating tooltip on mousehover
-// comment in the following line if you want a tooltip to display when the crosshair toggle is turned on
-// This should be used as an *alternative* to the HeadsUP (HUD).
-// new CIQ.Tooltip({stx:stxx, ohl:true, volume:true, series:true, studies:true});
-
-// Inactivity timer
-new CIQ.InactivityTimer({
-    stx: stxx,
-    minutes: 30,
-});
-
-// Animation (using tension requires splines.js)
-// new CIQ.Animation(stxx, {tension:0.3});
-
 
 function resizeScreen() {
     if (!UIContext) return;
@@ -487,12 +465,6 @@ function showMarkers(standardType) {
     }
     stxx.draw();
 }
-
-
-// Range Slider; needs to be created before startUI() is called for custom themes to apply
-new CIQ.RangeSlider({
-    stx: stxx,
-});
 
 let webComponentsSupported = ('registerElement' in document &&
     'import' in document.createElement('link') &&


### PR DESCRIPTION
![screen shot 2018-01-10 at 5 05 30 pm](https://user-images.githubusercontent.com/32833572/34764206-b1b8291e-f628-11e7-8eb1-06c2ff775cc6.png)

The advance template uses 3 things for `addOns.js`:
 - [`CIQ.ExtendedHours`](http://documentation.chartiq.com/CIQ.ExtendedHours.html#main)  shades areas where trading times is closed.
 - [`CIQ. InactivityTimer`](http://documentation.chartiq.com/CIQ.InactivityTimer.html#main) dims the chart when user does not interact with it. I don't see why we need this.
 - ['CIQ.RangeSlider`](http://documentation.chartiq.com/CIQ.RangeSlider.html#main) the range slider is similar to what we have in webtradercharts (click doc link to see how it looks). However I couldn't enable it and the demo in their doesn't use it anyway. If we want this, we will need to contact the chartiq ppl.

`addOns.js` also has [`CIQ.Animation`](http://documentation.chartiq.com/CIQ.Animation.html#main) which animates the chart (docs link has live example of this). This feature is what IQ options uses, albeit with some cosmetic tweaks.

 