### PR TITLE
add chart download

### DIFF
--- a/css/stx-chart.css
+++ b/css/stx-chart.css
@@ -15,6 +15,7 @@ html, body {
 
 .sharing .ciq-no-share {
     display: none !important;
+    left: -9999px !important;
 }
 
 /* --------------------------------------------------------- BUTTONS --------------------------------------------------------- */

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@ This is a fully functional example showing how to load a chart with a correspond
 <body>
     <div id="root"></div>
 
+    <script src="./chartiq/html2canvas.js"></script>
     <script src="./chartiq/jquery.js"></script>
     <script src="./chartiq/chartiq.js"></script>
     <script src="./chartiq/splines.js"></script>

--- a/sass/_ciq-components.scss
+++ b/sass/_ciq-components.scss
@@ -159,6 +159,7 @@ cq-loader {
 }
 cq-loader.stx-show{
 	display:block;
+	z-index: 9;
 }
 
 

--- a/src/BinaryChartiq.jsx
+++ b/src/BinaryChartiq.jsx
@@ -376,6 +376,7 @@ class BinaryChartiq extends Component {
                     }}>
                     </cq-overrides>
                 </cq-color-picker>
+                <cq-loader />
                 <div className="ciq-chart-area">
                     <div className="ciq-chart">
                         <cq-toolbar>
@@ -654,7 +655,6 @@ class BinaryChartiq extends Component {
                                     }}
                                 />
                             </cq-comparison>
-                            <cq-loader />
                             <cq-hu-static>
                                 <div>
                                     <div>Price</div>

--- a/src/components/Views.jsx
+++ b/src/components/Views.jsx
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import CIQ from 'chartiq';
 import React, { Component } from 'react';
 import contextAware from '../contextAware';
+import { downloadURI } from '../components/ui/utils';
 
 /**
  * Views web component `<cq-views>`.
@@ -151,12 +152,42 @@ class Views extends Component {
         if (this.params.renderCB) this.params.renderCB(menu);
     }
 
+    getChartFileName = (stx) => {
+        let unit, value;
+        if (typeof stx.layout.interval === 'string') {
+            value = stx.layout.periodicity;
+            unit = stx.layout.interval;
+        } else {
+            value = stx.layout.interval;
+            unit = stx.layout.timeUnit;
+        }
+        return `${stx.chart.symbol} (${value} ${unit}).png`;
+    }
+
     addNew = () => {
         let context = this._context;
         const viewDialog = $$$('cq-view-dialog', this._context.topNode);
         $(viewDialog).find('input').val('');
         viewDialog.open({
             context,
+        });
+    }
+
+    downloadChart = () => {
+        CIQ.UI.bypassBindings = true;
+        if (this._context.loader) {
+            this._context.loader.show();
+        }
+        const stx = this._context.stx;
+        CIQ.Share.createImage(stx, {
+            hide: ['#chartControls'],
+        }, (data) => {
+            CIQ.UI.bypassBindings = false;
+            if (this._context.loader) {
+                this._context.loader.hide();
+            }
+            const name = this.getChartFileName(stx);
+            downloadURI(data, name);
         });
     }
 
@@ -190,7 +221,7 @@ class Views extends Component {
                             <span>Add Template</span>
                         </div>
                         <div
-                            onClick={() => {}}
+                            onClick={this.downloadChart}
                             className="ciq-row"
                         >
                             <span className="ciq-icon ciq-ic-download" />

--- a/src/components/ui/utils.js
+++ b/src/components/ui/utils.js
@@ -58,3 +58,12 @@ export function setHidden(element, isHidden) {
         element.removeAttribute('hidden');
     }
 }
+
+export function downloadURI(uri, name) {
+    const link = document.createElement('a');
+    link.download = name;
+    link.href = uri;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+}


### PR DESCRIPTION
 - `<cq-loader/>` is moved to outside of chart area so it will not be rendered in the final image.
 - because of overlapping `display` with `!important` in css, the chart controls is hidden by positioning it off screen.