### PR TITLE
initial travis implementation, this adds:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+branches:
+  only:
+  - master
+notifications:
+  slack: binary-group:TI7oyWjkwf9Xx2Rllt2Pr5zY
+node_js:
+  - "8"
+before_script:
+  - yarn install
+script:
+  - yarn gh-pages -- --repo 'git@github.com:regentmarkets/chartiq.git'

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "analyze": "ANALYZE_BUNDLE=true webpack --progress",
     "watch": "webpack --progress --watch",
     "start": "rimraf dist && webpack-dev-server --open  --hot --inline",
-    "gh-pages": "yarn build && gh-pages --dist '.' --src '{index.html,dist/**,chartiq/chartiq.js,chartiq/jquery.js}' --add --repo 'git@github.com:aminroosta/chartiq-demo.git'"
+    "gh-pages": "yarn build && gh-pages --dist '.' --src '{index.html,dist/**,chartiq/chartiq.js,chartiq/jquery.js}' --add"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
 - slack notifications to #chartiq channel
 - auto deploy to https://chartiq-beta.binary.com/