### PR TITLE
use stages; prevent PR from deploying site.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,30 @@
 language: node_js
+
 branches:
   only:
   - master
+
 notifications:
   slack:
     rooms:
       - binary-group:TI7oyWjkwf9Xx2Rllt2Pr5zY
     on_pull_requests: false
+
 node_js:
   - "8"
-before_script:
+
+install:
   - yarn install
-after_success:
-  - yarn gh-pages -- --repo 'git@github.com:regentmarkets/chartiq.git'
+
+jobs:
+  include:
+    - stage: test
+      script: echo 'No tests are implemented yet...'
+    - stage: deploy
+      script:
+        - yarn gh-pages -- --repo 'git@github.com:regentmarkets/chartiq.git'
+
+stages:
+  - test
+  - name: deploy
+    if: type IS push


### PR DESCRIPTION
My mistake for the PRs being deployed. In this repo we use SSH authentication instead of GH_TOKEN, which also provides access for PR. To prevent this we use a conditional stage (similar to how cpp-pricing does it).