### PR TITLE
bug fix: comparisons disappears after refreshing twice.

### DIFF
--- a/src/store/TogglesStore.js
+++ b/src/store/TogglesStore.js
@@ -16,8 +16,8 @@ export default class TogglesStore {
                 this.context,
                 { autoStart: this.stx.layout.headsUp }
             );
-            this.setHeadsUp(this.stx.layout.headsUp);
-            this.setCrosshair(this.stx.layout.crosshair);
+            this.headsUp = this.stx.layout.headsUp;
+            this.crosshair = this.stx.layout.crosshair;
         }
     }
 


### PR DESCRIPTION
In TogglesStore, the layout is saved before the comparisons finished loading. On context ready, saveLayout should not be called.