### PR TITLE
fix bug where taps in iOS device on CategoricalDisplay doesn't work.

### DIFF
--- a/src/store/CategoricalDisplayStore.js
+++ b/src/store/CategoricalDisplayStore.js
@@ -66,6 +66,7 @@ export default class CategoricalDisplayStore {
         this.isInit = true;
         this.scroll = new IScroll(this.scrollPanel, {
             probeType: 2,
+            tap: true,
             mouseWheel: true,
             scrollbars: true,
         });


### PR DESCRIPTION
from iscrolljs docs:
```
To override the native scrolling iScroll has to inhibit some default browser behaviors, such as mouse clicks. If you want your application to respond to the click event you have to explicitly set this option to true.
```