### PR TITLE
Replace IScroll with perfect-scrollbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
     <script src="./dist/mobx.js"></script>
     <script src="./dist/mobx-react.js"></script>
     <script src="./dist/smartcharts.js"></script>
+    <link rel="stylesheet" href="./node_modules/perfect-scrollbar/css/perfect-scrollbar.css">
     <script>
         const e = React.createElement;
         const Barrier = smartcharts.Barrier;

--- a/index.html
+++ b/index.html
@@ -32,7 +32,6 @@
     <script src="./dist/mobx.js"></script>
     <script src="./dist/mobx-react.js"></script>
     <script src="./dist/smartcharts.js"></script>
-    <link rel="stylesheet" href="./node_modules/perfect-scrollbar/css/perfect-scrollbar.css">
     <script>
         const e = React.createElement;
         const Barrier = smartcharts.Barrier;

--- a/package.json
+++ b/package.json
@@ -71,10 +71,10 @@
     "create-react-class": "^15.6.3",
     "event-emitter-es6": "^1.1.5",
     "html2canvas": "^1.0.0-alpha.9",
-    "iscroll": "^5.2.0",
     "mobx": "^3.5.1",
     "mobx-react": "^4.4.1",
     "object.observe": "^0.2.6",
+    "perfect-scrollbar": "^1.3.0",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"

--- a/sass/_ciq-components.scss
+++ b/sass/_ciq-components.scss
@@ -40,6 +40,7 @@ cq-context {
 	@import "components/comparison-list";
 	@import "components/view";
 	@import "components/loader";
+	@import "ciq-perfect-scrollbar";
 }
 
 /* --------------------------------------------------------- FIELDS, SELECTS, INPUTS --------------------------------------------------------- */

--- a/sass/_ciq-perfect-scrollbar.scss
+++ b/sass/_ciq-perfect-scrollbar.scss
@@ -1,0 +1,112 @@
+/*
+ * Container style
+ */
+.ps {
+    overflow: hidden !important;
+    overflow-anchor: none;
+    -ms-overflow-style: none;
+    touch-action: auto;
+    -ms-touch-action: auto;
+}
+
+/*
+ * Scrollbar rail styles
+ */
+.ps__rail-x {
+    display: none;
+    opacity: 0;
+    transition: background-color .2s linear, opacity .2s linear;
+    -webkit-transition: background-color .2s linear, opacity .2s linear;
+    height: 15px;
+    /* there must be 'bottom' or 'top' for ps__rail-x */
+    bottom: 0px;
+    /* please don't change 'position' */
+    position: absolute;
+}
+
+.ps__rail-y {
+    display: none;
+    opacity: 0;
+    transition: background-color .2s linear, opacity .2s linear;
+    -webkit-transition: background-color .2s linear, opacity .2s linear;
+    width: 15px;
+    /* there must be 'right' or 'left' for ps__rail-y */
+    right: 0;
+    /* please don't change 'position' */
+    position: absolute;
+}
+
+.ps--active-x > .ps__rail-x,
+.ps--active-y > .ps__rail-y {
+    display: block;
+    background-color: transparent;
+}
+
+.ps:hover > .ps__rail-x,
+.ps:hover > .ps__rail-y,
+.ps--focus > .ps__rail-x,
+.ps--focus > .ps__rail-y,
+.ps--scrolling-x > .ps__rail-x,
+.ps--scrolling-y > .ps__rail-y {
+    opacity: 0.6;
+}
+
+.ps__rail-x:hover,
+.ps__rail-y:hover,
+.ps__rail-x:focus,
+.ps__rail-y:focus {
+    background-color: #eee;
+    opacity: 0.9;
+}
+
+/*
+ * Scrollbar thumb styles
+ */
+.ps__thumb-x {
+    background-color: #aaa;
+    border-radius: 6px;
+    transition: background-color .2s linear, height .2s ease-in-out;
+    -webkit-transition: background-color .2s linear, height .2s ease-in-out;
+    height: 6px;
+    /* there must be 'bottom' for ps__thumb-x */
+    bottom: 2px;
+    /* please don't change 'position' */
+    position: absolute;
+}
+
+.ps__thumb-y {
+    background-color: #aaa;
+    border-radius: 6px;
+    transition: background-color .2s linear, width .2s ease-in-out;
+    -webkit-transition: background-color .2s linear, width .2s ease-in-out;
+    width: 6px;
+    /* there must be 'right' for ps__thumb-y */
+    right: 2px;
+    /* please don't change 'position' */
+    position: absolute;
+}
+
+.ps__rail-x:hover > .ps__thumb-x,
+.ps__rail-x:focus > .ps__thumb-x {
+    background-color: #999;
+    height: 11px;
+}
+
+.ps__rail-y:hover > .ps__thumb-y,
+.ps__rail-y:focus > .ps__thumb-y {
+    background-color: #999;
+    width: 11px;
+}
+
+/* MS supports */
+@supports (-ms-overflow-style: none) {
+    .ps {
+        overflow: auto !important;
+    }
+}
+
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    .ps {
+        overflow: auto !important;
+    }
+}

--- a/src/store/CategoricalDisplayStore.js
+++ b/src/store/CategoricalDisplayStore.js
@@ -74,6 +74,7 @@ export default class CategoricalDisplayStore {
     }
 
     updateScrollSpy() {
+        if (this.pauseScrollSpy) return;
         if (this.filteredItems.length === 0) {return;}
 
         let i = 0;
@@ -104,7 +105,6 @@ export default class CategoricalDisplayStore {
     init() {
         this.isInit = true;
         this.scroll = new PerfectScrollbar(this.scrollPanel);
-        window.bobochacha = this.scroll;
 
         this.scrollPanel.addEventListener('ps-scroll-y', this.updateScrollSpy.bind(this));
 
@@ -185,12 +185,13 @@ export default class CategoricalDisplayStore {
     @action.bound handleFilterClick(category) {
         const el = this.categoryElements[category.categoryId];
         if (el) {
-            // TODO: Animation
+            // TODO: Scroll animation
+            this.pauseScrollSpy = true;
             this.scroll.element.scrollTop = el.offsetTop;
-            // TODO: the line above caused scroll event to execute, which in turn
-            //       changes this.activeCategoryKey. The hack below is not a pretty
-            //       solution.
-            setTimeout(() => this.activeCategoryKey = category.categoryId, 5);
+            this.activeCategoryKey = category.categoryId;
+            // scrollTop takes some time to take affect, so we need
+            // a slight delay before enabling the scroll spy again
+            setTimeout(() => this.pauseScrollSpy = false, 3);
         }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4417,10 +4417,6 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
-iscroll@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/iscroll/-/iscroll-5.2.0.tgz#d513307088b5b25a4f893af474804468481829c8"
-
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -5652,6 +5648,10 @@ pbkdf2@^3.0.3:
 pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+
+perfect-scrollbar@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/perfect-scrollbar/-/perfect-scrollbar-1.3.0.tgz#61da56f94b58870d8e0a617bce649cee17d1e3b2"
 
 performance-now@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Pros: 

 - by default it hides the scrollbar when not using, which is nice (I think there is setting for this also in iscroll)
 - `update` is not required to be called when contents of the scroll container increases in height
 - perfect-scrollbar is smaller (5.19K vs 8.39Kb)

Cons:
 
- perfect scrollbar does not have a `scrollToElement` function; examples online rely on jQuery to interpolate the `scrollTop` attribute. 