### PR TITLE
Drawing disappear after refresh. This will not support multiple charts

### DIFF
--- a/src/store/ChartStore.js
+++ b/src/store/ChartStore.js
@@ -94,10 +94,11 @@ class ChartStore {
 
     saveDrawings(target) {
         const obj = target.stx.exportDrawings();
+        const symbol = target.symbol;
         if (obj.length === 0) {
-            CIQ.localStorage.removeItem(obj.symbol);
+            CIQ.localStorage.removeItem(symbol);
         } else {
-            CIQ.localStorageSetItem(obj.symbol, JSON.stringify(obj));
+            CIQ.localStorageSetItem(symbol, JSON.stringify(obj));
         }
     }
     restoreDrawings(stx, symbol) {


### PR DESCRIPTION
@brucebinary  I separate this from the others, make new branch for my each task .

For now, all `target` return same `symbol` if they return different symbol, we can be able to save multiple chart draw