### PR TITLE
no scrolling to the future.

### DIFF
--- a/src/store/ChartStore.js
+++ b/src/store/ChartStore.js
@@ -146,6 +146,7 @@ class ChartStore {
     startUI() {
         const stxx = this.stxx;
         stxx.chart.allowScrollPast = false;
+        stxx.chart.allowScrollFuture = false;
         const context = new Context(stxx, this.rootNode);
 
         context.changeSymbol = (data) => {


### PR DESCRIPTION
In the future, we would want more control over this when placing trade visualizations in the chart, but in chart.binary.com it makes more sense to disable it