### PR TITLE
remove favorites from drawtools.

### DIFF
--- a/src/components/SettingsDialog.jsx
+++ b/src/components/SettingsDialog.jsx
@@ -17,6 +17,7 @@ const SettingsDialog = ({
     onStarClick,
     onResetClick,
     onItemChange,
+    isFavoritable,
     Dialog,
 }) => {
     const renderMap = {
@@ -80,10 +81,11 @@ const SettingsDialog = ({
                         onClick={onDeleteClick}
                         className="margin"
                     />
+                    { isFavoritable &&
                     <StarIcon
                         onClick={onStarClick}
                         className={`margin ${stared ? 'ciq-active-favorite' : ''}`}
-                    />
+                    />}
                 </div>
             </div>
 

--- a/src/store/DrawToolsStore.js
+++ b/src/store/DrawToolsStore.js
@@ -16,7 +16,6 @@ export default class DrawToolsStore {
         this.settingsDialog = new SettingsDialogStore({
             getContext: () => this.mainStore.chart.context,
             onDeleted: this.onDeleted,
-            onStared: this.onStared,
             onChanged: this.onChanged,
         });
 
@@ -141,11 +140,6 @@ export default class DrawToolsStore {
         }
         this.activeDrawing.highlighted = false;
         this.activeDrawing.adjust();
-    }
-
-    @action.bound onStared(value) {
-        console.warn('onStared not implemented yet.');
-        // TODO: implement favorites.
     }
 
     @action.bound onDeleted() {

--- a/src/store/SettingsDialogStore.js
+++ b/src/store/SettingsDialogStore.js
@@ -7,6 +7,7 @@ export default class SettingsDialogStore {
     @observable items = []; // [{id: '', title: '', value: ''}]
     @observable title = '';
     @observable stared = false;
+    @observable isFavoritable = true;
     @observable description = '';
 
     @observable activeTab = 'settings'; // 'settings' | 'description'
@@ -16,6 +17,7 @@ export default class SettingsDialogStore {
         this.getContext = getContext;
         this.onDeleted = onDeleted;
         this.onStared = onStared;
+        this.isFavoritable = onStared !== undefined;
         this.onChanged = onChanged;
 
         this.dialog = new DialogStore({ getContext });
@@ -69,6 +71,7 @@ export default class SettingsDialogStore {
             showTabs: this.showTabs,
             stared: this.stared,
             setOpen: this.setOpen,
+            isFavoritable: this.isFavoritable,
             onTabClick: this.onTabClick,
             onDeleteClick: this.onDeleteClick,
             onStarClick: this.onStarClick,

--- a/src/store/SettingsDialogStore.js
+++ b/src/store/SettingsDialogStore.js
@@ -7,7 +7,6 @@ export default class SettingsDialogStore {
     @observable items = []; // [{id: '', title: '', value: ''}]
     @observable title = '';
     @observable stared = false;
-    @observable isFavoritable = true;
     @observable description = '';
 
     @observable activeTab = 'settings'; // 'settings' | 'description'
@@ -17,7 +16,6 @@ export default class SettingsDialogStore {
         this.getContext = getContext;
         this.onDeleted = onDeleted;
         this.onStared = onStared;
-        this.isFavoritable = onStared !== undefined;
         this.onChanged = onChanged;
 
         this.dialog = new DialogStore({ getContext });
@@ -71,7 +69,7 @@ export default class SettingsDialogStore {
             showTabs: this.showTabs,
             stared: this.stared,
             setOpen: this.setOpen,
-            isFavoritable: this.isFavoritable,
+            isFavoritable: !!this.onStared,
             onTabClick: this.onTabClick,
             onDeleteClick: this.onDeleteClick,
             onStarClick: this.onStarClick,


### PR DESCRIPTION
May be temporary, depending when UX team come up with UI for favorites for drawtools. Until then we should not show it.