### PR TITLE
 Make chart title "look" like it's outside the chart

### DIFF
--- a/src/components/CategoricalDisplay.jsx
+++ b/src/components/CategoricalDisplay.jsx
@@ -1,7 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import {CategoryIconMap, ItemIconMap, SearchIcon,
     SymbolPlaceholderIcon, ActiveOptionsIconMap, FavoriteIcon, CloseIcon } from './Icons.jsx';
-import {stxtap} from '../store/utils';
 
 const CategoricalDisplay = ({
     isMobile,
@@ -19,7 +18,6 @@ const CategoricalDisplay = ({
     setScrollPanel,
     setCategoryElement,
     activeCategoryKey,
-    handleInputClick,
     onFavoritedItem,
     favoritesId,
     favoritesMap,
@@ -102,12 +100,7 @@ const CategoricalDisplay = ({
             <div className="cq-lookup-filters">
                 <div className={`cq-lookup-input ${filterText.trim() !== '' ? 'active':''}` }>
                     <input
-                        ref={
-                            el => {
-                                setSearchInput(el);
-                                stxtap(el, handleInputClick);
-                            }
-                        }
+                        ref={ el =>  setSearchInput(el)}
                         onChange={e => setFilterText(e.target.value)}
                         type="text"
                         spellCheck="off"
@@ -120,17 +113,17 @@ const CategoricalDisplay = ({
                     <CloseIcon className="icon-reset" onClick={ () =>clearFilterText() } />
                 </div>
                 <div className="cq-filter-panel">
-                { filteredItems.map((category, i) => {
-                    const CategoryIcon = CategoryIconMap[category.categoryId];
-                    const isActive = activeCategoryKey === category.categoryId;
-                    return (
-                        <div key={i}
-                            className={`cq-filter ${isActive ? 'cq-active-filter' : ''}`}
-                            ref={el => stxtap(el, e => handleFilterClick(category, e))}
-                         >
-                            {CategoryIcon && <CategoryIcon className={`ic-${category.categoryId}`}/>}
-                            <span className="cq-filter-text">{t.translate(category.categoryName)}</span>
-                        </div>);
+                    { filteredItems.map((category, i) => {
+                        const CategoryIcon = CategoryIconMap[category.categoryId];
+                        const isActive = activeCategoryKey === category.categoryId;
+                        return (
+                            <div key={i}
+                                className={`cq-filter ${isActive ? 'cq-active-filter' : ''}`}
+                                onClick={e => handleFilterClick(category, e)}
+                            >
+                                {CategoryIcon && <CategoryIcon className={`ic-${category.categoryId}`}/>}
+                                <span className="cq-filter-text">{t.translate(category.categoryName)}</span>
+                            </div>);
                     })}
                 </div>
             </div>
@@ -144,7 +137,7 @@ const CategoricalDisplay = ({
                                 ref={(el) => setCategoryElement(el, category.categoryId)}
                             >
                                 <div className="category-title">{t.translate(category.categoryName)}</div>
-                                { category.hasSubcategory 
+                                { category.hasSubcategory
                                     ? category.data.map((subcategory, j) =>
                                         getItemCount(subcategory) > 0 &&
                                         <Fragment key={j}>

--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -36,7 +36,16 @@ class Chart extends Component {
     }
 
     render() {
-        const { DrawToolsSettingsDialog, StudySettingsDialog, children, lang, isMobile, isChartAvailable, setting } = this.props;
+        const {
+            DrawToolsSettingsDialog,
+            StudySettingsDialog,
+            children,
+            lang,
+            isMobile,
+            isChartAvailable,
+            setting,
+            chartPanelTop,
+        } = this.props;
 
         t.setLanguage( (setting && setting.language) ? setting.language : lang );
         
@@ -54,13 +63,11 @@ class Chart extends Component {
                         <RenderInsideChart at='subholder'>
                             {insideSubHolder}
                         </RenderInsideChart>
-                        <RenderInsideChart>
-                            <div className="cq-top-ui-widgets">
-                                <ChartTitle />
-                                <AssetInformation />
-                                <ComparisonList />
-                            </div>
-                        </RenderInsideChart>
+                        <div className="cq-top-ui-widgets" style={{top: chartPanelTop}}>
+                            <ChartTitle />
+                            <AssetInformation />
+                            <ComparisonList />
+                        </div>
                         <ChartControls />
                         <Crosshair />
                         <div className="chartContainer primary"> </div>
@@ -78,7 +85,7 @@ class Chart extends Component {
         );
     }
 }
- 
+
 export default connect(
     ({chart, drawTools, studies}) => ({
         contextPromise: chart.contextPromise,
@@ -86,6 +93,7 @@ export default connect(
         StudySettingsDialog : studies.settingsDialog.connect(SettingsDialog),
         DrawToolsSettingsDialog : drawTools.settingsDialog.connect(SettingsDialog),
         isChartAvailable: chart.isChartAvailable,
-        setting: chart.setting
+        setting: chart.setting,
+        chartPanelTop: chart.chartPanelTop,
     })
 )(Chart);

--- a/src/store/CategoricalDisplayStore.js
+++ b/src/store/CategoricalDisplayStore.js
@@ -246,13 +246,6 @@ export default class CategoricalDisplayStore {
         return count;
     }
 
-    // In case where text input is inside chartContainer, it will not
-    // respond to mouse interaction. This is why we need to manually focus
-    // when user clicks on it.
-    @action.bound handleInputClick() {
-        this.searchInput.focus();
-    }
-
     @action.bound onFavoritedItem(item, e) {
         e.stopPropagation();
         e.nativeEvent.isHandledByDialog = true; // prevent close dialog
@@ -303,7 +296,6 @@ export default class CategoricalDisplayStore {
         setSearchInput: this.setSearchInput,
         handleFilterClick: this.handleFilterClick,
         onSelectItem: this.onSelectItem,
-        handleInputClick: this.handleInputClick,
         hasActiveItems: (this.getActiveCategory !== undefined),
         activeOptions: this.activeOptions,
         placeholderText: this.placeholderText,

--- a/src/store/ChartStore.js
+++ b/src/store/ChartStore.js
@@ -51,6 +51,7 @@ class ChartStore {
     @observable comparisonSymbols = [];
     @observable categorizedSymbols = [];
     @observable barrierJSX;
+    @observable chartPanelTop = '0px';
 
     @action.bound setActiveSymbols(activeSymbols) {
         if (activeSymbols && this.context) {
@@ -68,7 +69,6 @@ class ChartStore {
     }
 
     restoreLayout(stx) {
-
         let layoutData = CIQ.localStorage.getItem(`layout-${this.id}`);
 
         const checkForQuerystring = window.location.origin === 'https://charts.binary.com' ||
@@ -105,6 +105,7 @@ class ChartStore {
             CIQ.localStorageSetItem(symbol, JSON.stringify(obj));
         }
     }
+
     restoreDrawings(stx, symbol) {
         let memory = CIQ.localStorage.getItem(symbol);
         if (memory !== null) {
@@ -154,7 +155,6 @@ class ChartStore {
         const context = new Context(stxx, this.rootNode);
 
         // Put some margin so chart doesn't get blocked by chart title
-        // TODO: this will need to be removed if chart title is moved out of chart area
         stxx.chart.yAxis.initialMarginTop = 125;
         stxx.calculateYAxisMargins(stxx.chart.panel.yAxis);
 
@@ -238,8 +238,6 @@ class ChartStore {
         deleteElement.textConent = t.translate("right-click to delete");
         manageElement.textConent = t.translate("right-click to manage");
 
-
-
         // Animation (using tension requires splines.js)
         CIQ.Animation(stxx, { stayPut: true });
 
@@ -260,7 +258,11 @@ class ChartStore {
         //     minutes: 30,
         // });
 
-        stxx.addEventListener('layout', this.saveLayout.bind(this));
+        const holderStyle = stxx.chart.panel.holder.style;
+        stxx.addEventListener('layout', () => {
+            this.saveLayout();
+            this.chartPanelTop = holderStyle.top;
+        });
         stxx.addEventListener('symbolChange', (evt) => {
             if (this.onSymbolChange) { this.onSymbolChange(evt.symbolObject); }
             this.saveLayout.bind(this);
@@ -271,6 +273,7 @@ class ChartStore {
 
         this.startUI();
         this.resizeScreen();
+        this.chartPanelTop = holderStyle.top;
 
         window.addEventListener('resize', this.resizeScreen.bind(this));
 

--- a/translation/messages.pot
+++ b/translation/messages.pot
@@ -2,6 +2,9 @@
 msgid "CLOSED"
 msgstr ""
 
+msgid "Close"
+msgstr ""
+
 msgid "Favorites"
 msgstr ""
 
@@ -81,6 +84,18 @@ msgid "Clear All"
 msgstr ""
 
 msgid "Measure"
+msgstr ""
+
+msgid "Settings"
+msgstr ""
+
+msgid "Position"
+msgstr ""
+
+msgid "Theme"
+msgstr ""
+
+msgid "Language"
 msgstr ""
 
 msgid "Share"


### PR DESCRIPTION
I manage to place the chart title such that it _look_ like it's inside the chart. This will solve all the styling issues, as well as enabling us to select text in the active symbol selector, and resolves all tap issues in mobile devices