### PR TITLE
update height of chartContainer to make space for chart controls

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -33,7 +33,7 @@ const getLanguageStorage = function(){
 };
 
 const connectionManager = new ConnectionManager({
-    appId: 1,
+    appId: 12812,
     language: getLanguageStorage(),
     endpoint: 'wss://frontend.binaryws.com/websockets/v3',
 });

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -35,7 +35,7 @@ const getLanguageStorage = function(){
 const connectionManager = new ConnectionManager({
     appId: 12812,
     language: getLanguageStorage(),
-    endpoint: 'wss://frontend.binaryws.com/websockets/v3',
+    endpoint: 'wss://ws.binaryws.com/websockets/v3',
 });
 
 const streamManager = new StreamManager(connectionManager);

--- a/src/store/ChartStore.js
+++ b/src/store/ChartStore.js
@@ -94,9 +94,8 @@ class ChartStore {
 
     updateHeight() {
         const ciqNode = this.rootNode.querySelector('.ciq-chart');
-        let ciqHeight = ciqNode.offsetHeight;
-        ciqHeight += ciqNode.classList.contains('toolbar-on') ? -45 : 0;
-
+        const chartControls = ciqNode.querySelector('.cq-chart-controls');
+        let ciqHeight = ciqNode.offsetHeight - chartControls.offsetHeight;
         const containerNode = this.rootNode.querySelector('.chartContainer.primary');
         containerNode.style.height = `${ciqHeight}px`;
     }


### PR DESCRIPTION
for some reason `offsetHeight` of `.ciq-chart` doesn't factor the height of the chart controls in beta. Since I can't figure out why, I just add the calculation manually