### PR TITLE
simplify StudyLegend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ enableRouting | Enable routing for dialogs. Defaults to `false`
 
 | Attribute | Description |
 --------|--------------
-showCountdown | Show Countdown. Defaults to `false`.
+countdown | Show Countdown. Defaults to `false`.
 theme | Sets the chart theme. themes are (`dark\|light`), and default is `light`.
 lang | Sets the language. Defaults to `en`.
 position | Sets the position of the chart controls. Choose between `left` and `bottom`. In mobile this is always `bottom`. Defaults to `bottom`.

--- a/src/components/StudyLegend.jsx
+++ b/src/components/StudyLegend.jsx
@@ -1,53 +1,42 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Menu from './Menu.jsx';
 import CategoricalDisplay from './CategoricalDisplay.jsx';
 import { connect } from '../store/Connect';
 import { IndicatorIcon } from './Icons.jsx';
 
-class StudyLegend extends Component {
-    componentWillUnmount() {
-        this.props.cleanUp();
-    }
-
-    render() {
-        const {
-            isOpened,
-            setOpen,
-            Menu,
-            menuOpen,
-            StudyCategoricalDisplay,
-            onCloseMenu,
-            isMobile,
-        } = this.props;
-
-        return (
-            <Menu
-                className="ciq-menu ciq-studies collapse"
-                isOpened={isOpened}
-                setOpen={setOpen}
-                isMobile={isMobile}
-            >
-                <Menu.Title>
-                    <IndicatorIcon
-                        className={`ic-icon-with-sub ${menuOpen ? 'active' : ''}`}
-                        tooltip-title={t.translate('Indicators')}
-                    />
-                </Menu.Title>
-                <Menu.Body>
-                    <StudyCategoricalDisplay
-                        dialogTitle={t.translate('Indicators')}
-                        closeMenu={() => onCloseMenu()}
-                    />
-                </Menu.Body>
-            </Menu>
-        );
-    }
-}
+const StudyLegend = ({
+    isOpened,
+    setOpen,
+    Menu,
+    menuOpen,
+    StudyCategoricalDisplay,
+    onCloseMenu,
+    isMobile,
+}) => (
+    <Menu
+        className="ciq-menu ciq-studies collapse"
+        isOpened={isOpened}
+        setOpen={setOpen}
+        isMobile={isMobile}
+    >
+        <Menu.Title>
+            <IndicatorIcon
+                className={`ic-icon-with-sub ${menuOpen ? 'active' : ''}`}
+                tooltip-title={t.translate('Indicators')}
+            />
+        </Menu.Title>
+        <Menu.Body>
+            <StudyCategoricalDisplay
+                dialogTitle={t.translate('Indicators')}
+                closeMenu={() => onCloseMenu()}
+            />
+        </Menu.Body>
+    </Menu>
+);
 
 export default connect(({ studies: st }) => ({
     isOpened: st.open,
     setOpen: st.setOpen,
-    cleanUp: st.cleanUp,
     Menu: st.menu.connect(Menu),
     menuOpen: st.menu.open,
     StudyCategoricalDisplay: st.categoricalDisplay.connect(CategoricalDisplay),

--- a/src/store/StudyLegendStore.js
+++ b/src/store/StudyLegendStore.js
@@ -42,7 +42,6 @@ export default class StudyLegendStore {
         this.renderLegend();
     };
 
-    injections = [];
     previousStudies = { };
 
     @observable activeStudies = {

--- a/src/store/StudyLegendStore.js
+++ b/src/store/StudyLegendStore.js
@@ -36,7 +36,10 @@ export default class StudyLegendStore {
     get stx() { return this.context.stx; }
 
     onContextReady = () => {
-        this.begin();
+        this.stx.callbacks.studyOverlayEdit = this.editStudy;
+        this.stx.callbacks.studyPanelEdit = this.editStudy;
+        this.stx.append('createDataSet', this.renderLegend);
+        this.renderLegend();
     };
 
     injections = [];
@@ -49,13 +52,6 @@ export default class StudyLegendStore {
         emptyDescription: t.translate('There are no active indicators yet.'),
         data: [],
     };
-
-    begin() {
-        this.stx.callbacks.studyOverlayEdit = this.editStudy;
-        this.stx.callbacks.studyPanelEdit = this.editStudy;
-        this.injections.push(this.stx.append('createDataSet', () => this.renderLegend()));
-        this.renderLegend();
-    }
 
     get categorizedStudies() {
         const data = [];
@@ -203,11 +199,11 @@ export default class StudyLegendStore {
     /**
      * Gets called continually in the draw animation loop.
      * Be careful not to render unnecessarily. */
-    renderLegend() {
+    renderLegend = () => {
         if (!this.shouldRenderLegend()) { return; }
 
         this.updateActiveStudies();
-    }
+    };
 
     @action.bound updateActiveStudies() {
         const stx = this.stx;
@@ -230,15 +226,6 @@ export default class StudyLegendStore {
         });
 
         this.activeStudies.data = studies;
-    }
-
-    @action.bound cleanUp() {
-        if (this.context && this.injections) {
-            for (const inj of this.injections) {
-                this.stx.removeInjection(inj);
-            }
-            this.injections = [];
-        }
     }
 
     @action.bound clearStudies() {


### PR DESCRIPTION
It is not necessary to have a method `cleanUp`, in fact that is precisely _not_ the behaviour we want. We don't want the injection to be removed when the component unmounts; there is no code that calls the injection to be reintroduced when it does get mounted again. The injection should be valid throughout the life of the `<SmartCharts />` component, and removed only when `<SmartCharts />` is unmounted (via `ChartStore.destroy()`).