### PR TITLE
Bug fix: pagination happens past endEpoch

### DIFF
--- a/src/feed/Feed.js
+++ b/src/feed/Feed.js
@@ -162,7 +162,8 @@ class Feed {
     }
 
     async _getPaginationData(symbol, granularity, start, end, callback) {
-        if (this.startEpoch && start < this.startEpoch) {
+        if (this.startEpoch && start < this.startEpoch
+            || this.endEpoch && end > this.endEpoch) {
             callback({ moreAvailable: false, quotes: [] });
             return;
         }


### PR DESCRIPTION
ChartIQ 6.1 adds ability to paginate to the right, we need to halt it when endEpoch point is reached