### PR TITLE
bug fix: exchange_is_open is undefined

### DIFF
--- a/src/binaryapi/ActiveSymbols.js
+++ b/src/binaryapi/ActiveSymbols.js
@@ -29,7 +29,10 @@ export default class ActiveSymbols {
         }
         this._tradingTimes.onMarketOpenCloseChanged(action((changes) => {
             for (const symbol in changes) {
-                this.symbolMap[symbol].exchange_is_open = changes[symbol];
+                const symObj = this.symbolMap[symbol];
+                if (symObj) {
+                    symObj.exchange_is_open = changes[symbol];
+                }
             }
             this.changes = changes;
         }));


### PR DESCRIPTION
It would seem that the market symbols we display from `active_symbols` to the user depends on where they live as well. In austrailia, only 49 symbols are available but we have 56 here. However, on the `trading_times` API this is not the case; it shows everything. Thus, there is no one-to-one correlation for the symbols in `trading_times` and `active_symbols` API.