### PR TITLE
Morteza/current_spot_sold_contracts

### DIFF
--- a/src/store/ChartState.js
+++ b/src/store/ChartState.js
@@ -176,6 +176,7 @@ class ChartState {
             this.stxx.chart.panel.yAxis.drawCurrentPriceLabel = !this.endEpoch;
             this.stxx.preferences.currentPriceLine = !this.endEpoch;
             this.stxx.isAutoScale = this.settings && settings.isAutoScale !== false;
+            this.stxx.draw();
         }
     }
 


### PR DESCRIPTION
Fixed the issue of showing current spot, line and label price for sold contracts