### PR TITLE
shayan/remove importedLayout feature

### DIFF
--- a/src/store/ChartStore.js
+++ b/src/store/ChartStore.js
@@ -521,11 +521,6 @@ class ChartStore {
                     }
                 }));
 
-                if (this.state.importedLayout) {
-                    // Check if there is a layout set by importedLayout porp, import it here after chart is loaded
-                    this.state.importLayout();
-                }
-
                 stxx.container.addEventListener('mouseenter', this.onMouseEnter);
                 stxx.container.addEventListener('mouseleave', this.onMouseLeave);
 
@@ -536,7 +531,7 @@ class ChartStore {
                     this.state.symbol,
                     this.state.granularity,
                 ], () => {
-                    if (this.state.symbol !== undefined || (this.state.granularity !== undefined && !this.state.importedLayout)) {
+                    if (this.state.symbol !== undefined || (this.state.granularity !== undefined)) {
                         this.changeSymbol(this.state.symbol, this.state.granularity);
                     }
                 });


### PR DESCRIPTION
it seems `deriv-app` no longer use `importedLayout` to build chart. as result we are going to remove importedLayout feature in SmartChart.