### PR TITLE
Bala/raw-marker-injection-fix

### DIFF
--- a/src/components/RawMarker.jsx
+++ b/src/components/RawMarker.jsx
@@ -9,11 +9,14 @@ class RawMarker extends React.Component {
     ctx = null;
     stx = null;
     injectionId = null;
+    hasUnmountedBeforeInjection = false;
 
     componentDidMount() {
         const { contextPromise } = this.props;
 
         contextPromise.then((ctx) => {
+            if (this.hasUnmountedBeforeInjection) { return; }
+
             this.ctx = ctx;
             this.stx = this.ctx.stx;
 
@@ -28,6 +31,8 @@ class RawMarker extends React.Component {
             this.stx.removeInjection(this.injectionId);
             this.ctx = null;
             this.stx = null;
+        } else {
+            this.hasUnmountedBeforeInjection = true;
         }
     }
 


### PR DESCRIPTION
RawMarkers are injected even after unmount sometimes. Because of that same markers are shown more than once(overlapping) and extra markers stays even after changing the symbol