### PR TITLE
shayan/chart overlapping with bottom widgets in contract details

### DIFF
--- a/src/components/BottomWidgetsContainer.jsx
+++ b/src/components/BottomWidgetsContainer.jsx
@@ -14,7 +14,9 @@ class BottomWidgetsContainer extends React.Component {
     }
 
     componentDidUpdate() {
-        if (React.Children.count(this.props.children)) {
+        const component = React.Children.only(this.props.children);
+
+        if (component && component.props.bottomWidgets) {
             this.props.updateChartMargin(200);
         } else {
             this.props.updateChartMargin(100);


### PR DESCRIPTION
the main issue comes from the `componentDidUpdate` method in `BottomWidgetsContainer.jsx` which we determine if the chart has bottomWidget or not. 

Regarding the rendering part of bottomWidget in the `Chart.jsx`
```
<BottomWidgetsContainer>
    <BottomWidget bottomWidgets={bottomWidgets} />
</BottomWidgetsContainer>
```
`BottomWidgetsContainer` component always has a children named `BottomWidget` (whether the BottomWidget component suppose to render null or and DOM element).
As a result, I suppose to change the condition in the `componentDidUpdate` method in `BottomWidgetsContainer.jsx`. this way the bottom widget margin calculation applies only if we have it.
