### PR TITLE
Shayan/initial resize event after chart get ready

### DIFF
--- a/src/store/ChartState.js
+++ b/src/store/ChartState.js
@@ -344,6 +344,7 @@ class ChartState {
             this.isChartReady = isChartReady;
 
             if (isChartReady) {
+                this.chartStore.setResizeEvent();
                 this.stateChange(STATE.READY);
             }
 

--- a/src/store/ChartStore.js
+++ b/src/store/ChartStore.js
@@ -832,23 +832,25 @@ class ChartStore {
                 })
             );
         });
+    }
 
+    setResizeEvent = () => {
         if ('ResizeObserver' in window) {
             this.resizeObserver = new ResizeObserver(this.resizeScreen);
-            this.resizeObserver.observe(rootNode);
+            this.resizeObserver.observe(this.rootNode);
         } else {
             import(/* webpackChunkName: "resize-observer-polyfill" */ 'resize-observer-polyfill').then(
                 ({ default: ResizeObserver }) => {
                     window.ResizeObserver = ResizeObserver;
-                    if (stxx.isDestroyed || !rootNode) {
+                    if (this.stxx.isDestroyed || !this.rootNode) {
                         return;
                     }
                     this.resizeObserver = new ResizeObserver(this.resizeScreen);
-                    this.resizeObserver.observe(rootNode);
+                    this.resizeObserver.observe(this.rootNode);
                 }
             );
         }
-    }
+    };
 
     onMarketOpenClosedChange = changes => {
         const symbolObjects = this.stxx.getSymbols().map(item => item.symbolObject);


### PR DESCRIPTION
- The main problem comes from the place, where we set resize events. seems the chart height reduce to `zero` for a second without reason, and that causes the ResizeObserver to crash and finally chart treat wrongly with top/bottom margin