### PR TITLE
fix/ disable browser-detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,6 @@
 
     <body>
         <div id="root" role="main"></div>
-        <!-- <script src="./dist/browser-detection.js?709cd41c"></script> -->
         <script src="./dist/babel-polyfill.min.js?5090bae2"></script>
         <script src="./dist/react.js?edf56a42"></script>
         <script src="./dist/react-dom.js?dcf51763"></script>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 
     <body>
         <div id="root" role="main"></div>
-        <script src="./dist/browser-detection.js?709cd41c"></script>
+        <!-- <script src="./dist/browser-detection.js?709cd41c"></script> -->
         <script src="./dist/babel-polyfill.min.js?5090bae2"></script>
         <script src="./dist/react.js?edf56a42"></script>
         <script src="./dist/react-dom.js?dcf51763"></script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -180,7 +180,7 @@ if (isApp) {
             patterns: [
                 { from: './sass/favicons/*.png' },
                 { from: './node_modules/@babel/polyfill/dist/polyfill.min.js', to: 'babel-polyfill.min.js' },
-                { from: './app/browser-detection.js' },
+                // { from: './app/browser-detection.js' },
                 { from: './app/assets/*.svg' },
                 { from: './nojs-smartcharts.css' },
                 {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -180,7 +180,6 @@ if (isApp) {
             patterns: [
                 { from: './sass/favicons/*.png' },
                 { from: './node_modules/@babel/polyfill/dist/polyfill.min.js', to: 'babel-polyfill.min.js' },
-                // { from: './app/browser-detection.js' },
                 { from: './app/assets/*.svg' },
                 { from: './nojs-smartcharts.css' },
                 {


### PR DESCRIPTION
since we have a problem with macOS chrome which instead of showing the chart, it shows an error message about unsupported browser, I disable the browser-detection script as a temporary solution so we can fix the problem later.
