### PR TITLE
kate/86796/remove console warnings from SmartCharts localhost

### DIFF
--- a/src/components/categoricaldisplay/FilterPanel.tsx
+++ b/src/components/categoricaldisplay/FilterPanel.tsx
@@ -74,7 +74,7 @@ const FilterGroup = React.memo(
                         }
 
                         return (
-                            <div
+                            <div key={subgroup?.categoryId}
                                 className={`sc-mcd__filter__subgroups-item ${isGroupActive ? 'sc-mcd__filter__item--active' : ''} ${isActive && !isSearching ? 'sc-mcd__filter__item--selected' : ''}`}
                                 onClick={() => handleFilterClick(subgroup.categoryId)}
                             >

--- a/src/components/categoricaldisplay/ResultsPanel.tsx
+++ b/src/components/categoricaldisplay/ResultsPanel.tsx
@@ -214,10 +214,10 @@ const ResultsPanel = ({
                         />
                     )
                 );
-            } else {
+            } 
                 return (
                     (categoryItemCount > 0 || category.emptyDescription) && (
-                        <React.Fragment>
+                        <React.Fragment key={category.categoryId}>
                             <Category
                                 key={category.categoryId}
                                 ItemType={ItemType}
@@ -246,7 +246,7 @@ const ResultsPanel = ({
                                                 disableAll={disableAll}
                                                 isNestedList={isNestedList}
                                                 handleTitleClick={handleTitleClick}
-                                                hasSubgroup={true}
+                                                hasSubgroup
                                                 favoritesId={favoritesId}
                                             />
                                         );
@@ -256,7 +256,7 @@ const ResultsPanel = ({
                         </React.Fragment>
                     )
                 )
-            }
+            
         })}
     </>
 );


### PR DESCRIPTION
In FilterGroup and ResultsPanel components there was no key after .map method and that caused console errors.
Delete extra 'else' statement, because in 'if' we have return.