### PR TITLE
kate/80870/fix: add optional chaining in updateScrollSpy function

### DIFF
--- a/src/store/CategoricalDisplayStore.ts
+++ b/src/store/CategoricalDisplayStore.ts
@@ -303,7 +303,7 @@ export default class CategoricalDisplayStore {
             const r = el.getBoundingClientRect();
             const top = r.top - scrollPanelTop - gap_top;
             if (top < 0) {
-                activeMenuId = category.hasSubgroup ? category.subgroups[+(r.top < 0)].categoryId : category.categoryId;
+                activeMenuId = category.hasSubgroup ? category.subgroups[+(r.top < 0)]?.categoryId : category?.categoryId;
             }
         }
 


### PR DESCRIPTION
The issue from TrackJS.
In some cases (after switching to/between major pairs or cryptocurrency) this line of code throw an error, as categoryId is undefined: 
_activeMenuId = category.hasSubgroup ? category.subgroups[+(r.top < 0)]?.categoryId : category?.categoryId;_  
Added optional chaining operator 