### PR TITLE
Amir/feq 294/upgrade espree package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@deriv/deriv-charts",
-    "version": "1.2.2",
+    "version": "1.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@deriv/deriv-charts",
-            "version": "1.2.2",
+            "version": "1.3.0",
             "license": "ISC",
             "dependencies": {
                 "@welldone-software/why-did-you-render": "^3.3.8",
@@ -75,7 +75,7 @@
                 "eslint-plugin-promise": "^4.2.1",
                 "eslint-plugin-react": "^7.14.3",
                 "eslint-plugin-react-hooks": "^4.1.2",
-                "espree": "^6.0.0",
+                "espree": "^9.5.2",
                 "estree-walk": "^2.2.0",
                 "fork-ts-checker-webpack-plugin": "^6.5.0",
                 "fs": "^0.0.1-security",
@@ -3158,18 +3158,6 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3364,18 +3352,6 @@
                 "supports-color": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
@@ -9037,18 +9013,6 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/eslint/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/eslint/node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -9164,29 +9128,32 @@
             }
         },
         "node_modules/espree": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
-            "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+            "version": "9.5.2",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
+            "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
             "dev": true,
             "dependencies": {
-                "acorn": "^7.1.1",
-                "acorn-jsx": "^5.2.0",
-                "eslint-visitor-keys": "^1.1.0"
+                "acorn": "^8.8.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
-                "node": ">=6.0.0"
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/espree/node_modules/acorn": {
-            "version": "7.4.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+        "node_modules/espree/node_modules/eslint-visitor-keys": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+            "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
             "dev": true,
-            "bin": {
-                "acorn": "bin/acorn"
-            },
             "engines": {
-                "node": ">=0.4.0"
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/esprima": {
@@ -10380,18 +10347,6 @@
             },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/fork-ts-checker-webpack-plugin/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/fork-ts-checker-webpack-plugin/node_modules/parse-json": {
@@ -13666,18 +13621,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
-        },
-        "node_modules/lint-staged/node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/lint-staged/node_modules/parse-json": {
             "version": "5.1.0",
@@ -24531,15 +24474,6 @@
                 "@swc/wasm": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/ts-node/node_modules/acorn-walk": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/ts-node/node_modules/diff": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "eslint-plugin-promise": "^4.2.1",
         "eslint-plugin-react": "^7.14.3",
         "eslint-plugin-react-hooks": "^4.1.2",
-        "espree": "^6.0.0",
+        "espree": "^9.5.2",
         "estree-walk": "^2.2.0",
         "fork-ts-checker-webpack-plugin": "^6.5.0",
         "fs": "^0.0.1-security",

--- a/scripts/extract-translations.js
+++ b/scripts/extract-translations.js
@@ -13,7 +13,6 @@ const default_options = {
 const parseCode = source => espree.parse(source, {
     ecmaVersion: 10,
     sourceType: 'script',
-    tolerant: true,
     loc: true,
 }).body;
 

--- a/scripts/extract-translations.js
+++ b/scripts/extract-translations.js
@@ -11,7 +11,7 @@ const default_options = {
 };
 
 const parseCode = source => espree.parse(source, {
-    ecmaVersion: 'latest',
+    ecmaVersion: 11,
     sourceType: 'script',
     loc: true,
 }).body;

--- a/scripts/extract-translations.js
+++ b/scripts/extract-translations.js
@@ -11,7 +11,7 @@ const default_options = {
 };
 
 const parseCode = source => espree.parse(source, {
-    ecmaVersion: 10,
+    ecmaVersion: 'latest',
     sourceType: 'script',
     loc: true,
 }).body;


### PR DESCRIPTION
## Summary

- https://github.com/eslint/espree/pull/546 confirms the support of node 18 in espree v9
- Ticker is working fine
- Menu switching working fine
- Changing language working fine
- No breaking change on v7 except the drop of node v8 support
- Breaking changes in the v8 with drop of node v10/13/15 support and other breaking changes is validated in the code
- Breaking change in v9 is the drop of using char  as a variable name since this is a resrved keyword in es3 but I found no usage of this reserved keyword in the code
- Removed tolerant  property from espree options since this is ignored in the package