### PR TITLE
Maryia/opt-324/Update chart rescaling features

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,10 +195,11 @@ Props marked with `*` are **mandatory**:
 | countdown                    | Show Countdown. Defaults to `false`.                                                                                                  |
 | theme                        | Sets the chart theme. themes are (`dark\|light`), and default is `light`.                                                             |
 | lang                         | Sets the language. Defaults to `en`.                                                                                                  |
+| minimumLeftBars              | The default number of bars to display on the chart. It's used in combination with `whitespace` setting in order to adjust white space width. Please refer to `whitespace` below for more details. Defaults to `undefined`.                                                                                                  |
 | position                     | Sets the position of the chart controls. Choose between `left` and `bottom`. In mobile this is always `bottom`. Defaults to `bottom`. |
 | enabledNavigationWidget      | Show or hide navigation widget. Defaults to `false`                                                                                   |
 | isHighestLowestMarkerEnabled | Show or hide the highest and lowest tick on the chart. Defaults to `false`.                                                           |
-| whitespace                    | The initial amount of whitespace to display between the right edge of the chart and the y-axis. White space width also depends on `maxTick` prop value. Please refer to stxx.preferences.whitespace in CIQ documentation for more details. Defaults to `undefined`.                                                                                                  |
+| whitespace                    | The default width of whitespace between the right edge of the chart and the y-axis. It should be used in combination with `minimumLeftBars` setting value. For more details, please refer to stxx.preferences.whitespace in CIQ documentation. Defaults to `undefined`.                                                                                                  |
 
 #### InitialData
 

--- a/src/store/BottomWidgetsContainerStore.ts
+++ b/src/store/BottomWidgetsContainerStore.ts
@@ -70,7 +70,9 @@ export default class BottomWidgetsContainerStore {
             ) {
                 this.stx.chart.yAxis.initialMarginTop = marginTop;
                 this.stx.chart.yAxis.initialMarginBottom = marginBottom;
-                this.stx.chart.yAxis.heightFactor = this.state.heightFactor;
+                if (this.state.heightFactor) {
+                    this.stx.chart.yAxis.heightFactor = this.state.heightFactor;
+                }
                 this.stx.calculateYAxisMargins(this.stx.chart.panel.yAxis);
                 this.stx.draw();
             }

--- a/src/store/ChartSettingStore.ts
+++ b/src/store/ChartSettingStore.ts
@@ -17,6 +17,7 @@ export default class ChartSettingStore {
     historical = false;
     isAutoScale = true;
     isHighestLowestMarkerEnabled = true;
+    minimumLeftBars?: number;
     whitespace?: number;
 
     constructor(mainStore: MainStore) {
@@ -28,6 +29,7 @@ export default class ChartSettingStore {
             historical: observable,
             isAutoScale: observable,
             isHighestLowestMarkerEnabled: observable,
+            minimumLeftBars: observable,
             updateActiveLanguage: action.bound,
             setLanguage: action.bound,
             setTheme: action.bound,
@@ -79,6 +81,7 @@ export default class ChartSettingStore {
             countdown,
             historical,
             language,
+            minimumLeftBars,
             position,
             isAutoScale,
             isHighestLowestMarkerEnabled,
@@ -108,6 +111,7 @@ export default class ChartSettingStore {
         if (language !== undefined) {
             this.setLanguage(language);
         }
+        this.setMinimumLeftBars(minimumLeftBars);
         if (historical !== undefined) {
             this.setHistorical(historical);
         }
@@ -117,9 +121,7 @@ export default class ChartSettingStore {
         if (isHighestLowestMarkerEnabled !== undefined) {
             this.toggleHighestLowestMarker(isHighestLowestMarkerEnabled);
         }
-        if (whitespace !== undefined) {
-            this.setWhiteSpace(whitespace);
-        }
+        this.setWhiteSpace(whitespace);
     }
     saveSetting() {
         if (this.onSettingsChange && this.language) {
@@ -130,7 +132,9 @@ export default class ChartSettingStore {
                 position: this.position,
                 isAutoScale: this.isAutoScale,
                 isHighestLowestMarkerEnabled: this.isHighestLowestMarkerEnabled,
+                minimumLeftBars: this.minimumLeftBars,
                 theme: this.theme,
+                whitespace: this.whitespace,
             });
         }
     }
@@ -231,7 +235,15 @@ export default class ChartSettingStore {
         logEvent(LogCategories.ChartControl, LogActions.ChartSetting, ` Change AutoScale to ${value}`);
         this.saveSetting();
     }
-    setWhiteSpace(value: number) {
+    setMinimumLeftBars(value?: number) {
+        if (this.minimumLeftBars === value) {
+            return;
+        }
+        this.minimumLeftBars = value;
+        logEvent(LogCategories.ChartControl, LogActions.ChartSetting, ` Change MinimumLeftBars to ${value}`);
+        this.saveSetting();
+    }
+    setWhiteSpace(value?: number) {
         if (this.whitespace === value) {
             return;
         }

--- a/src/store/ChartState.ts
+++ b/src/store/ChartState.ts
@@ -9,6 +9,7 @@ import {
     TSettings,
 } from 'src/types';
 import { AuditDetailsForExpiredContract, ProposalOpenContract } from '@deriv/api-types';
+import { isDeepEqual } from 'src/utils/object';
 import MainStore from '.';
 import Theme from '../../sass/_themes.scss';
 import { STATE } from '../Constant';
@@ -36,6 +37,7 @@ class ChartState {
     chartStore: ChartStore;
     getIndicatorHeightRatio?: TGetIndicatorHeightRatio;
     shouldDrawTicksFromContractInfo? = false;
+    has_updated_settings = false;
     isAnimationEnabled?: boolean;
     mainStore: MainStore;
     margin?: number;
@@ -111,6 +113,7 @@ class ChartState {
             startEpoch: observable,
             endEpoch: observable,
             symbol: observable,
+            has_updated_settings: observable,
             heightFactor: observable,
             isConnectionOpened: observable,
             isChartReady: observable,
@@ -226,6 +229,7 @@ class ChartState {
         this.isConnectionOpened = isConnectionOpened;
         this.isStaticChart = isStaticChart;
         this.margin = margin;
+        this.has_updated_settings = !isDeepEqual(this.settings?.whitespace, settings?.whitespace);
         this.settings = settings;
         this.should_show_eu_content = should_show_eu_content;
         this.shouldFetchTradingTimes = shouldFetchTradingTimes;
@@ -395,7 +399,10 @@ class ChartState {
             this.stxx.chart.panel.yAxis.drawCurrentPriceLabel = !this.endEpoch;
             this.stxx.preferences.currentPriceLine = !this.endEpoch;
             this.stxx.isAutoScale = this.settings && this.settings.isAutoScale !== false;
+            this.stxx.preferences.whitespace = this.settings?.whitespace || this.chartStore.whitespace;
+            this.stxx.minimumLeftBars = this.settings?.minimumLeftBars || this.chartStore.defaultMinimumBars;
             this.stxx.draw();
+            if (this.has_updated_settings) this.stxx.home();
         }
     }
 

--- a/src/store/ChartStore.ts
+++ b/src/store/ChartStore.ts
@@ -172,9 +172,9 @@ class ChartStore {
     onMessage = null;
     defaultMinimumBars = 5;
     _barriers: BarrierStore[] = [];
-
     tradingTimes?: TradingTimes;
     activeSymbols?: ActiveSymbols;
+    whitespace?: number;
     get loader() {
         return this.mainStore.loader;
     }
@@ -762,6 +762,7 @@ class ChartStore {
         chartSetting.onSettingsChange = onSettingsChange;
         localStorage.setItem('current_chart_lang', settings?.language || 'en');
         this.isMobile = isMobile;
+        this.whitespace = isMobile ? 50 : 150;
         this.state = this.mainStore.state;
         this.mainStore.notifier.onMessage = onMessage;
         this.granularity = granularity !== undefined ? granularity : this.defaults.granularity;
@@ -774,7 +775,7 @@ class ChartStore {
             yaxisLabelStyle: 'roundRect',
             preferences: {
                 currentPriceLine: true,
-                whitespace: settings?.whitespace || (isMobile ? 50 : 150),
+                whitespace: settings?.whitespace || this.whitespace,
             },
             chart: {
                 yAxis: {
@@ -792,7 +793,7 @@ class ChartStore {
                 gaplines: true,
                 dynamicYAxis: true,
             },
-            minimumLeftBars: this.defaultMinimumBars,
+            minimumLeftBars: settings?.minimumLeftBars || this.defaultMinimumBars,
             yTolerance: 999999,
         };
         let chartLayout = {

--- a/src/types/props.types.ts
+++ b/src/types/props.types.ts
@@ -73,6 +73,7 @@ export type TSettings = {
     historical?: boolean;
     lang?: string;
     language?: string;
+    minimumLeftBars?: number;
     position?: string;
     enabledNavigationWidget?: boolean;
     isAutoScale?: boolean;

--- a/src/utils/__tests__/index.spec.ts
+++ b/src/utils/__tests__/index.spec.ts
@@ -87,4 +87,14 @@ describe('getYAxisScalingParams', () => {
             },
         });
     });
+    it('should return an object with heightfactor only when yaxis_height is undefined', () => {
+        expect(
+            getYAxisScalingParams({
+                is_mobile: true,
+                yaxis_height: undefined,
+                is_contract_chart: true,
+                ticks_length: 2,
+            })
+        ).to.deep.equal({ height_factor });
+    });
 });

--- a/src/utils/__tests__/index.spec.ts
+++ b/src/utils/__tests__/index.spec.ts
@@ -87,7 +87,7 @@ describe('getYAxisScalingParams', () => {
             },
         });
     });
-    it('should return an object with heightfactor only when yaxis_height is undefined', () => {
+    it('should return an object with height_factor only when yaxis_height is undefined', () => {
         expect(
             getYAxisScalingParams({
                 is_mobile: true,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -170,7 +170,7 @@ export const getYAxisScalingParams: TGetYAxisScalingParams = ({
     }
     return {
         ...params,
-        ...(yaxis_height ? { yaxis_margin: { top, bottom } } : {}),
+        ...(top && bottom ? { yaxis_margin: { top, bottom } } : {}),
     };
 };
 


### PR DESCRIPTION
- added `minimumLeftBars` setting used for adjusting white space width,
- autoscroll to the latest spot if `settings` got updated after chart initialization,
- prevented setting heightFactor if undefined,
- prevented setting yAxis top & bottom when yAxis height is undefined.