### PR TITLE
Maryia/FEQ-829/TrackJS fix: Cannot find modalEnd when stx is undefined

### DIFF
--- a/src/store/MenuStore.ts
+++ b/src/store/MenuStore.ts
@@ -50,6 +50,7 @@ export default class MenuStore {
     blurInput() {
         const stx: Context['stx'] = this.context?.stx;
         setTimeout(this.handleDialogStatus, 300);
+        if (!stx) return;
         if (this.open === false) {
             (document.activeElement as HTMLElement).blur();
             stx.modalEnd();


### PR DESCRIPTION
- To fix TrackJS error: "["[mobx] uncaught error in 'Reaction[Reaction]'",{"name":"TypeError","message":"Cannot read properties of undefined (reading 'modalEnd')","stack":"TypeError: Cannot read properties of undefined (reading 'modalEnd')"