### PR TITLE
[DTRA] Maryia/DTRA-572/fix: Barrier titles are not displayed

### DIFF
--- a/src/components/PriceLine.tsx
+++ b/src/components/PriceLine.tsx
@@ -15,6 +15,7 @@ type TPriceLineProps = {
     foregroundColor: string;
     color?: string;
     opacityOnOverlap: number;
+    title?: string;
     width: number;
 };
 
@@ -28,6 +29,7 @@ const PriceLine = ({
     hideOffscreenLine,
     hideBarrierLine,
     store,
+    title,
 }: TPriceLineProps) => {
     const {
         className,
@@ -40,7 +42,6 @@ const PriceLine = ({
         offScreenDirection,
         priceDisplay,
         setDragLine,
-        title,
         visible,
         yAxiswidth,
     } = store;


### PR DESCRIPTION
To display barrier title together with a price line label on the chart.

The title can be the limit_order.stop_out.display_name or limit_order.take_profit.display_name or limit_order.stop_loss.display_name from proposal_open_contract API.

After the fix, the title will be displayed next to the barrier label like this:
<img width="1192" alt="Screenshot 2023-12-14 at 8 38 40 PM" src="https://github.com/binary-com/SmartCharts/assets/103177211/ebf4bfa1-6741-4b3a-940d-7f5fbae3a30d">
