### PR TITLE
[DTRA] Maryia/DTRA-572/fix: barrier title

### DIFF
--- a/src/components/PriceLine.tsx
+++ b/src/components/PriceLine.tsx
@@ -15,6 +15,7 @@ type TPriceLineProps = {
     foregroundColor: string;
     color?: string;
     opacityOnOverlap: number;
+    title?: string;
 };
 
 const PriceLine = ({
@@ -26,6 +27,7 @@ const PriceLine = ({
     hideOffscreenLine,
     hideBarrierLine,
     store,
+    title,
 }: TPriceLineProps) => {
     const {
         className,
@@ -41,7 +43,6 @@ const PriceLine = ({
         priceDisplay,
         priceLineWidth,
         setDragLine,
-        title,
         visible,
     } = store;
 
@@ -59,6 +60,7 @@ const PriceLine = ({
     if (!showBarrier) return null;
 
     const width = priceLineWidth + 12;
+    const price_right_offset = (isOverlappingWithPriceLine ? width - overlappedBarrierWidth : 0) + (isMobile ? 20 : 4);
 
     return (
         <div
@@ -88,13 +90,12 @@ const PriceLine = ({
                 <div className='draggable-area' />
                 <div className='draggable-area-wrapper'>
                     <div
-                        className={'drag-price'}
+                        className='drag-price'
                         style={{
                             backgroundColor: color,
                             width: isOverlappingWithPriceLine ? overlappedBarrierWidth : width,
                             opacity,
-                            right:
-                                (isOverlappingWithPriceLine ? width - overlappedBarrierWidth : 0) + (isMobile ? 20 : 4),
+                            right: price_right_offset,
                         }}
                     >
                         <HamburgerDragIcon />
@@ -122,7 +123,12 @@ const PriceLine = ({
                     )}
                 </div>
                 {title && (
-                    <PriceLineTitle color={color} title={title} yAxiswidth={overlappedBarrierWidth} opacity={opacity} />
+                    <PriceLineTitle
+                        color={color}
+                        title={title}
+                        yAxiswidth={width + price_right_offset}
+                        opacity={opacity}
+                    />
                 )}
             </div>
         </div>


### PR DESCRIPTION
To display barrier title together with a price line label on the chart.

The title can be the limit_order.stop_out.display_name or limit_order.take_profit.display_name or limit_order.stop_loss.display_name from proposal_open_contract API.

After the fix, the title will be displayed next to the barrier label like this:
<img width="1221" alt="Screenshot 2023-12-27 at 3 01 02 PM" src="https://github.com/binary-com/SmartCharts/assets/103177211/1014fb6b-bd39-4f7c-8800-f4798dd28c4a">