### PR TITLE
Akmal / fix: sync shaded area with current spot barrier

### DIFF
--- a/sass/components/_barrier.scss
+++ b/sass/components/_barrier.scss
@@ -205,7 +205,6 @@
     right: 0;
     height: 120px !important;
     opacity: 0.3;
-    transition: all 0.1s ease-out;
 }
 
 /* css gradients are only partially supported in Safari, but will work here since colors are not premultiplied */

--- a/src/store/BarrierStore.ts
+++ b/src/store/BarrierStore.ts
@@ -113,6 +113,8 @@ export default class BarrierStore {
             () => [this.mainStore.chartAdapter.epochBounds, this.mainStore.chartAdapter.quoteBounds],
             this._drawShadedArea
         );
+
+        this.mainStore.chartAdapter.painter.registerCallback(this._drawShadedArea);
     };
 
     init(): void {
@@ -194,6 +196,9 @@ export default class BarrierStore {
         this._low_barrier.destructor();
 
         this.disposeDrawReaction?.();
+
+        this.mainStore.chartAdapter.painter.unregisterCallback(this._drawShadedArea);
+
 
         const i = this.mainStore.chart._barriers.findIndex((b: BarrierStore) => b === this);
         if (i !== -1) {


### PR DESCRIPTION
This update resolves an issue where the shaded area was not synchronizing properly with the current spot barrier. Previously, discrepancies between the shaded area and the spot barrier could occur, leading to confusion and inconsistency in visual representations. With this fix, the shaded area now accurately reflects changes in the current spot barrier, ensuring alignment between visual elements and actual data. Users can now rely on the shaded area to dynamically adjust in response to modifications in the spot barrier, enhancing clarity and coherence in the representation of relevant information.