### PR TITLE
Maryia/build: update npm version to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@deriv/deriv-charts",
-    "version": "2.0.5",
+    "version": "2.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@deriv/deriv-charts",
-            "version": "2.0.5",
+            "version": "2.1.0",
             "license": "ISC",
             "dependencies": {
                 "@types/lodash.set": "^4.3.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@deriv/deriv-charts",
-    "version": "2.0.5",
+    "version": "2.1.0",
     "main": "dist/smartcharts.js",
     "author": "amin@binary.com",
     "contributors": [


### PR DESCRIPTION
- bumping up the major version because the new version will contain a breaking change in the usage of exported `ChartMode` and `Views` components.