### PR TITLE
build(deps): bump js-yaml and babel-plugin-inline-react-svg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
                 "@typescript-eslint/parser": "^4.28.0",
                 "babel-eslint": "^10.0.2",
                 "babel-loader": "^8.0.6",
-                "babel-plugin-inline-react-svg": "^1.1.0",
+                "babel-plugin-inline-react-svg": "^2.0.2",
                 "babel-plugin-istanbul": "^5.2.0",
                 "babel-plugin-transform-runtime": "^6.23.0",
                 "chai": "^4.2.0",
@@ -5076,101 +5076,168 @@
             }
         },
         "node_modules/babel-plugin-inline-react-svg": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/babel-plugin-inline-react-svg/-/babel-plugin-inline-react-svg-1.1.2.tgz",
-            "integrity": "sha512-oDR/eraFbMtvg4bDxv4W8bQWTDxLVkKpIYKx0cey/J2QqFyogyQOvEz9SjSYmNK3jI+yZdVMAshTwkKnj6J/Aw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-inline-react-svg/-/babel-plugin-inline-react-svg-2.0.2.tgz",
+            "integrity": "sha512-iM9obPpCcdPE1EJE+UF+tni7CZ4q/OvdDm/TeBBHAYAEOqDcFd7fdnmym6OYAQMYfEpUnRYUYx2KxSUyo4cQxQ==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@babel/parser": "^7.0.0",
                 "lodash.isplainobject": "^4.0.6",
-                "resolve": "^1.10.0",
-                "svgo": "^0.7.2"
+                "resolve": "^2.0.0-next.4",
+                "svgo": "^2.8.0"
+            },
+            "engines": {
+                "node": ">=10.13"
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0"
             }
         },
-        "node_modules/babel-plugin-inline-react-svg/node_modules/colors": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-            "integrity": "sha512-ENwblkFQpqqia6b++zLD/KUWafYlVY/UNnAp7oz7LY7E924wmpye416wBOmvv/HMWzl8gL1kJlfvId/1Dg176w==",
+        "node_modules/babel-plugin-inline-react-svg/node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
             "dev": true,
             "engines": {
-                "node": ">=0.1.90"
+                "node": ">= 10"
+            }
+        },
+        "node_modules/babel-plugin-inline-react-svg/node_modules/css-select": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+            "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+            "dev": true,
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.0.1",
+                "domhandler": "^4.3.1",
+                "domutils": "^2.8.0",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/babel-plugin-inline-react-svg/node_modules/css-tree": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+            "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+            "dev": true,
+            "dependencies": {
+                "mdn-data": "2.0.14",
+                "source-map": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
             }
         },
         "node_modules/babel-plugin-inline-react-svg/node_modules/csso": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
-            "integrity": "sha512-FmCI/hmqDeHHLaIQckMhMZneS84yzUZdrWDAvJVVxOwcKE1P1LF9FGmzr1ktIQSxOw6fl3PaQsmfg+GN+VvR3w==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+            "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
             "dev": true,
             "dependencies": {
-                "clap": "^1.0.9",
-                "source-map": "^0.5.3"
-            },
-            "bin": {
-                "csso": "bin/csso"
+                "css-tree": "^1.1.2"
             },
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=8.0.0"
             }
         },
-        "node_modules/babel-plugin-inline-react-svg/node_modules/esprima": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-            "integrity": "sha512-OarPfz0lFCiW4/AV2Oy1Rp9qu0iusTKqykwTspGCZtPxmF81JR4MmIebvF1F9+UOKth2ZubLQ4XGGaU+hSn99A==",
-            "dev": true,
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/babel-plugin-inline-react-svg/node_modules/js-yaml": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-            "integrity": "sha512-eIlkGty7HGmntbV6P/ZlAsoncFLGsNoM27lkTzS+oneY/EiNhj+geqD9ezg/ip+SW6Var0BJU2JtV0vEUZpWVQ==",
+        "node_modules/babel-plugin-inline-react-svg/node_modules/dom-serializer": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
             "dev": true,
             "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^2.6.0"
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.2.0",
+                "entities": "^2.0.0"
             },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
             }
         },
-        "node_modules/babel-plugin-inline-react-svg/node_modules/source-map": {
-            "version": "0.5.7",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+        "node_modules/babel-plugin-inline-react-svg/node_modules/domhandler": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
             "dev": true,
+            "dependencies": {
+                "domelementtype": "^2.2.0"
+            },
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/babel-plugin-inline-react-svg/node_modules/domutils": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "dev": true,
+            "dependencies": {
+                "dom-serializer": "^1.0.1",
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/babel-plugin-inline-react-svg/node_modules/entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/babel-plugin-inline-react-svg/node_modules/mdn-data": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+            "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+            "dev": true
+        },
+        "node_modules/babel-plugin-inline-react-svg/node_modules/resolve": {
+            "version": "2.0.0-next.5",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+            "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+            "dev": true,
+            "dependencies": {
+                "is-core-module": "^2.13.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/babel-plugin-inline-react-svg/node_modules/svgo": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
-            "integrity": "sha512-jT/g9FFMoe9lu2IT6HtAxTA7RR2XOrmcrmCtGnyB/+GQnV6ZjNn+KOHZbZ35yL81+1F/aB6OeEsJztzBQ2EEwA==",
-            "deprecated": "This SVGO version is no longer supported. Upgrade to v2.x.x.",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+            "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
             "dev": true,
             "dependencies": {
-                "coa": "~1.0.1",
-                "colors": "~1.1.2",
-                "csso": "~2.3.1",
-                "js-yaml": "~3.7.0",
-                "mkdirp": "~0.5.1",
-                "sax": "~1.2.1",
-                "whet.extend": "~0.9.9"
+                "@trysound/sax": "0.2.0",
+                "commander": "^7.2.0",
+                "css-select": "^4.1.3",
+                "css-tree": "^1.1.3",
+                "csso": "^4.2.0",
+                "picocolors": "^1.0.0",
+                "stable": "^0.1.8"
             },
             "bin": {
                 "svgo": "bin/svgo"
             },
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=10.13.0"
             }
         },
         "node_modules/babel-plugin-istanbul": {
@@ -6006,73 +6073,6 @@
                 "safe-buffer": "^5.0.1"
             }
         },
-        "node_modules/clap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-            "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^1.1.3"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/clap/node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/clap/node_modules/ansi-styles": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/clap/node_modules/chalk": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/clap/node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/clap/node_modules/supports-color": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-            "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
         "node_modules/class-utils": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -6216,18 +6216,6 @@
             "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/coa": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
-            "integrity": "sha512-KAGck/eNAmCL0dcT3BiuYwLbExK6lduR8DxM3C1TyDzaXhZHyZ8ooX5I5+na2e3dPFuibfxrGdorr0/Lr7RYCQ==",
-            "dev": true,
-            "dependencies": {
-                "q": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
             }
         },
         "node_modules/collection-visit": {
@@ -23821,15 +23809,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.8.0"
-            }
-        },
-        "node_modules/whet.extend": {
-            "version": "0.9.9",
-            "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
-            "integrity": "sha512-mmIPAft2vTgEILgPeZFqE/wWh24SEsR/k+N9fJ3Jxrz44iDFy9aemCxdksfURSHYFCLmvs/d/7Iso5XjPpNfrA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.6.0"
             }
         },
         "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "@typescript-eslint/parser": "^4.28.0",
         "babel-eslint": "^10.0.2",
         "babel-loader": "^8.0.6",
-        "babel-plugin-inline-react-svg": "^1.1.0",
+        "babel-plugin-inline-react-svg": "^2.0.2",
         "babel-plugin-istanbul": "^5.2.0",
         "babel-plugin-transform-runtime": "^6.23.0",
         "chai": "^4.2.0",


### PR DESCRIPTION
Bumps [js-yaml](https://github.com/nodeca/js-yaml) to 3.14.1 and updates ancestor dependency [babel-plugin-inline-react-svg](https://github.com/kesne/babel-plugin-inline-react-svg). These dependencies need to be updated together.


Updates `js-yaml` from 3.7.0 to 3.14.1
- [Changelog](https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md)
- [Commits](https://github.com/nodeca/js-yaml/compare/3.7.0...3.14.1)

Updates `babel-plugin-inline-react-svg` from 1.1.2 to 2.0.2
- [Changelog](https://github.com/airbnb/babel-plugin-inline-react-svg/blob/master/CHANGELOG.md)
- [Commits](https://github.com/kesne/babel-plugin-inline-react-svg/compare/1.1.2...v2.0.2)

---
updated-dependencies:
- dependency-name: js-yaml dependency-type: indirect
- dependency-name: babel-plugin-inline-react-svg dependency-type: direct:development ...